### PR TITLE
Fix wrong reference to CONF_ID instead of CONF_ZONE_ID in IUZone load.

### DIFF
--- a/custom_components/irrigation_unlimited/irrigation_unlimited.py
+++ b/custom_components/irrigation_unlimited/irrigation_unlimited.py
@@ -1397,7 +1397,7 @@ class IUZone(IUBase):
     def load(self, config: OrderedDict, all_zones: OrderedDict) -> "IUZone":
         """Load zone data from the configuration"""
         self.clear()
-        self._zone_id = config.get(CONF_ID, str(self.index + 1))
+        self._zone_id = config.get(CONF_ZONE_ID, str(self.index + 1))
         self._is_enabled = config.get(CONF_ENABLED, True)
         self._name = config.get(CONF_NAME, None)
         self._switch_entity_id = config.get(CONF_ENTITY_ID)


### PR DESCRIPTION
Fix the bug discussed in issue https://github.com/rgc99/irrigation_unlimited/issues/54#issue-1205112948 under "Additional suggestions" point 1.