### PR TITLE
Correct unit of measurement

### DIFF
--- a/packages/irrigation_unlimited_lts.yaml
+++ b/packages/irrigation_unlimited_lts.yaml
@@ -3,6 +3,6 @@ template:
     - name: Today Total C1 Z1
       state_class: total_increasing
       icon: mdi:sprinkler
-      unit_of_measurement: s
+      unit_of_measurement: m
       state: >
         {{ state_attr('binary_sensor.irrigation_unlimited_c1_z1', 'today_total') | float(0) }}


### PR DESCRIPTION
The `unit_of_measurement` is `m` instead of `s`