### PR TITLE
FIX: Moved percent sign to right

### DIFF
--- a/custom_components/irrigation_unlimited/irrigation_unlimited.py
+++ b/custom_components/irrigation_unlimited/irrigation_unlimited.py
@@ -454,13 +454,16 @@ class IUAdjustment:
             elif method == "-":
                 self._method = CONF_DECREASE
                 self._time_adjustment = wash_td(str_to_td(adj))
+            elif adjustment[-1] == '%':
+                self._method = CONF_PERCENTAGE
+                self._time_adjustment = float(adjustment[:-1])
 
     def __str__(self) -> str:
         """Return the adjustment as a string notation"""
         if self._method == CONF_ACTUAL:
             return f"={self._time_adjustment}"
         if self._method == CONF_PERCENTAGE:
-            return f"%{self._time_adjustment}"
+            return f"{self._time_adjustment}%"
         if self._method == CONF_INCREASE:
             return f"+{self._time_adjustment}"
         if self._method == CONF_DECREASE:


### PR DESCRIPTION
Hi. Thanks for all the work on this.

With that being said, the formatting of the percent sign was driving me crazy. :) In the US, at least, the percent sign goes after the number. I see you're from AU, and I thought it was the same?

Assuming that there are some locales where % comes before the number, that formatting should be handled by HA, but I couldn't find any useful l10n code.