### PR TITLE
Enhance pause/resume functionality

### DIFF
--- a/custom_components/irrigation_unlimited/irrigation_unlimited.py
+++ b/custom_components/irrigation_unlimited/irrigation_unlimited.py
@@ -1636,7 +1636,9 @@ class IURun(IUBase):
         """Resume a paused run"""
         if self.expired or self._pause_time is None:
             return
-        delta = stime - self._pause_time
+        delta = stime - max(self._pause_time, self._start_time)
+        if delta < TD_ZERO:
+            delta = TD_ZERO
         self._start_time += delta
         self._end_time += delta
         self._pause_time = None
@@ -3345,7 +3347,10 @@ class IUSequenceRun(IUBase):
         if self._paused is None:
             return
         resume_run(stime, self._runs)
-        self._end_time += stime - self._paused
+        delta = stime - max(self._paused, self._start_time)
+        if delta < TD_ZERO:
+            delta = TD_ZERO
+        self._end_time += delta
         self._paused = None
         self.update_status(stime)
 
@@ -4396,6 +4401,14 @@ class IUSequence(IUBase):
             ):
                 sqr.pause(stime)
                 changed = True
+
+        # If nothing is currently active then pause the next scheduled run.
+        if not changed:
+            for sqr in self._run_queue:
+                if not sqr.expired and not sqr.paused:
+                    sqr.pause(stime)
+                    changed = True
+                    break
         return changed
 
     def service_resume(self, data: MappingProxyType, stime: datetime) -> bool:

--- a/tests/test_service_sequence_pause_resume.py
+++ b/tests/test_service_sequence_pause_resume.py
@@ -189,6 +189,38 @@ async def test_service_sequence_pause_resume_notify(
         exam.check_summary()
 
 
+async def test_service_sequence_pause_before_start(
+    hass: ha.HomeAssistant, skip_dependencies, skip_history
+):
+    """Pause a sequence before runtime and ensure it starts on resume."""
+    async with IUExam(hass, "service_sequence_pause_resume_multi.yaml") as exam:
+        await exam.begin_test(1)
+
+        await exam.run_until("2023-11-28 06:03:00")
+        await exam.call(
+            SERVICE_PAUSE,
+            {
+                "entity_id": "binary_sensor.irrigation_unlimited_c1_s1",
+            },
+        )
+        exam.check_iu_entity("c1_s1", "on", {"status": "paused"})
+        exam.check_iu_entity("c1_z1", "off", {})
+
+        # The scheduled run is now due but should stay paused until resume.
+        await exam.run_until("2023-11-28 06:06:00")
+        exam.check_iu_entity("c1_s1", "on", {"status": "paused"})
+        exam.check_iu_entity("c1_z1", "off", {})
+
+        await exam.call(
+            SERVICE_RESUME,
+            {
+                "entity_id": "binary_sensor.irrigation_unlimited_c1_s1",
+            },
+        )
+        exam.check_iu_entity("c1_s1", "on", {"status": "on"})
+        exam.check_iu_entity("c1_z1", "on", {})
+
+
 async def test_service_sequence_pause_resume_multi(
     hass: ha.HomeAssistant, skip_dependencies, skip_history
 ):


### PR DESCRIPTION
This changes sequence pause/resume behavior so a pause is retained even when the sequence is not currently running. If a scheduled run becomes due while paused, it stays paused instead of starting, and starts immediately when resumed.

This is useful for setups like mine where grid connectivity is unreliable and the house may fall back to battery power. My inverter does not handle the water pump well while on batteries, so I need to pause irrigation during outages and resume it once mains power is back, without losing the scheduled run.