### PR TITLE
Handle incomplete restored run timers

### DIFF
--- a/custom_components/irrigation_unlimited/irrigation_unlimited.py
+++ b/custom_components/irrigation_unlimited/irrigation_unlimited.py
@@ -1641,6 +1641,11 @@ class IURun(IUBase):
     def update_time_remaining(self, stime: datetime) -> bool:
         """Update the count down timers"""
         if self.running:
+            if self._start_time is None or self._end_time is None:
+                self._remaining_time = TD_ZERO
+                self._percent_complete = 0
+                self._status = IURunStatus.EXPIRED
+                return True
             self._remaining_time = self._end_time - stime
             duration: timedelta = self._end_time - self._start_time
             elapsed: timedelta = stime - self._start_time
@@ -3506,6 +3511,11 @@ class IUSequenceRun(IUBase):
         """Update the count down timers"""
         if not (self.running or self.paused):
             return False
+        if self._start_time is None or self._end_time is None:
+            self._remaining_time = TD_ZERO
+            self._percent_complete = 0
+            self._status = IURunStatus.EXPIRED
+            return True
         self._remaining_time = self._end_time - stime
         elapsed = stime - self._start_time
         duration = self._end_time - self._start_time

--- a/tests/test_sequence_run.py
+++ b/tests/test_sequence_run.py
@@ -9,10 +9,45 @@ from custom_components.irrigation_unlimited.const import (
     SERVICE_SUSPEND,
     SERVICE_TIME_ADJUST,
 )
-from custom_components.irrigation_unlimited.irrigation_unlimited import IUSequenceRun
+from custom_components.irrigation_unlimited.irrigation_unlimited import (
+    IURun,
+    IURunStatus,
+    IUSequenceRun,
+)
+from custom_components.irrigation_unlimited.util import TD_ZERO
 from tests.iu_test_support import IUExam, mk_local, mk_utc
 
 IUExam.quiet_mode()
+
+
+def test_sequence_run_ignores_incomplete_restored_timer():
+    """Test restored running sequence runs with missing times do not crash."""
+    run = IUSequenceRun.__new__(IUSequenceRun)
+    run._status = IURunStatus.RUNNING
+    run._start_time = mk_utc("2021-01-04 06:05")
+    run._end_time = None
+    run._remaining_time = None
+    run._percent_complete = 50
+
+    assert run.update_time_remaining(mk_utc("2021-01-04 06:07"))
+    assert run._status == IURunStatus.EXPIRED
+    assert run._remaining_time == TD_ZERO
+    assert run._percent_complete == 0
+
+
+def test_run_ignores_incomplete_restored_timer():
+    """Test restored running runs with missing times do not crash."""
+    run = IURun.__new__(IURun)
+    run._status = IURunStatus.RUNNING
+    run._start_time = mk_utc("2021-01-04 06:05")
+    run._end_time = None
+    run._remaining_time = None
+    run._percent_complete = 50
+
+    assert run.update_time_remaining(mk_utc("2021-01-04 06:07"))
+    assert run._status == IURunStatus.EXPIRED
+    assert run._remaining_time == TD_ZERO
+    assert run._percent_complete == 0
 
 
 async def test_sequence_run(hass: ha.HomeAssistant, skip_dependencies, skip_history):


### PR DESCRIPTION
## Summary

This prevents restored run timers with incomplete start/end times from crashing the coordinator update loop.

When Home Assistant restores an in-progress irrigation run after a restart, the run can still be marked as running/paused while one of the timer boundaries is missing. In that state `update_time_remaining()` currently attempts to subtract `None` from `datetime`, which repeatedly raises:

```text
TypeError: unsupported operand type(s) for -: NoneType and datetime.datetime
```

The fix treats these incomplete restored timers as expired, resets the timer counters, and lets the run queue continue cleaning itself up instead of keeping the event loop stuck on the exception.

## Validation

```text
python3 -m compileall custom_components/irrigation_unlimited tests/test_sequence_run.py
uv run --python /opt/homebrew/bin/python3.14 --with-requirements requirements_test.txt python -m pytest tests/test_sequence_run.py::test_sequence_run_ignores_incomplete_restored_timer tests/test_sequence_run.py::test_run_ignores_incomplete_restored_timer
```
