### PR TITLE
Fix IUVolume: skip first tick to avoid unreliable flow rate at valve …

### DIFF
--- a/custom_components/irrigation_unlimited/irrigation_unlimited.py
+++ b/custom_components/irrigation_unlimited/irrigation_unlimited.py
@@ -1220,7 +1220,6 @@ class IUVolume:
         value = float(sensor.state)
         if value < 0:
             raise ValueError(f"Negative sensor value: {sensor.state}")
-
         current_reading = IUVolumeSensorReading(
             stime, Decimal(f"{value * self._volume_scale:.{self._volume_precision}f}")
         )
@@ -1247,26 +1246,53 @@ class IUVolume:
                     f"current: {current_reading.value}"
                 )
 
-            # Total
-            self._total_volume = current_reading.value - self._first_reading.value
-            total_time = current_reading.timestamp - self._first_reading.timestamp
+            # Skip the first interval after a new recording starts.
+            # A pulse-based flow meter has a fixed resolution: each pulse
+            # represents a fixed volume (e.g. 1 litre/pulse or 1/96 litre/pulse).
+            # At the moment the valve opens, the counter may be anywhere within
+            # the current pulse interval. The first tick therefore represents only
+            # the remaining fraction of that interval, not a full pulse volume of
+            # actual flow since opening.
+            #
+            # Example with 1 litre/pulse resolution:
+            #   Counter is at 0.99 L into the current pulse when the valve opens.
+            #   The first tick fires after only 0.01 L of actual flow (0.6 s on a
+            #   3 l/min line), yet is counted as 1 L → apparent flow = 100 l/min.
+            #   On a low-flow circuit (3 l/min, 1 pulse every ~20 s) the error is
+            #   far greater than on a high-flow circuit (17 l/min, 1 pulse every
+            #   ~3.5 s) because the time_delta is proportionally shorter relative
+            #   to the pulse interval.
+            #
+            # Resetting first_reading to the current tick discards this unreliable
+            # first interval. All subsequent calculations start from a clean
+            # baseline where a complete pulse interval has elapsed since opening.
 
-            # SMA
-            rate = volume_delta * Decimal(self._flow_rate_scale) / time_delta
-            self._flow_rate_sum += rate
-            self._flow_rates.append(rate)
-            if len(self._flow_rates) > IUVolume.SMA_WINDOW:
-                self._flow_rate_sum -= self._flow_rates.pop(0)
-            # pylint: disable=invalid-unary-operand-type
-            self._flow_rate_sma = (
-                self._flow_rate_sum / len(self._flow_rates)
-            ).quantize(Decimal(10) ** -self._flow_rate_precision)
+            if self._total_readings == 1:
+                self._first_reading = current_reading
+                self._total_volume = 0
+                self._flow_rate_sma = 0
+                self._flow_rate_avg = 0
+            else:
+                # Total
+                self._total_volume = current_reading.value - self._first_reading.value
+                total_time = current_reading.timestamp - self._first_reading.timestamp
 
-            # AVG
-            if (secs := total_time.total_seconds()) > 0:
-                self._flow_rate_avg = (
-                    self._total_volume * Decimal(self._flow_rate_scale) / Decimal(secs)
+                # SMA
+                rate = volume_delta * Decimal(self._flow_rate_scale) / time_delta
+                self._flow_rate_sum += rate
+                self._flow_rates.append(rate)
+                if len(self._flow_rates) > IUVolume.SMA_WINDOW:
+                    self._flow_rate_sum -= self._flow_rates.pop(0)
+                # pylint: disable=invalid-unary-operand-type
+                self._flow_rate_sma = (
+                    self._flow_rate_sum / len(self._flow_rates)
                 ).quantize(Decimal(10) ** -self._flow_rate_precision)
+
+                # AVG
+                if (secs := total_time.total_seconds()) > 0:
+                    self._flow_rate_avg = (
+                        self._total_volume * Decimal(self._flow_rate_scale) / Decimal(secs)
+                    ).quantize(Decimal(10) ** -self._flow_rate_precision)
         else:
             self._first_reading = current_reading
             self._total_volume = 0
@@ -1278,8 +1304,6 @@ class IUVolume:
         self._sensor_readings.append(current_reading)
         if len(self._sensor_readings) > IUVolume.MAX_READINGS:
             self._sensor_readings.pop(0)
-
-        return
 
     def event_hook(self, event: HAEvent) -> HAEvent:
         """A pass through place for testing to patch and update


### PR DESCRIPTION
## Problem

When a zone starts, `IUVolume._read_sensor` calculates the flow rate using
the first two sensor ticks. With a pulse-based flow meter (e.g. 1 pulse/litre),
this first interval produces a wildly inflated flow rate.

### Root cause

A pulse counter has a fixed resolution: each pulse represents a fixed volume.
At the moment the valve opens, the counter may be anywhere within the current
pulse interval. The first tick therefore represents only the remaining fraction
of that interval, not a full pulse volume of actual flow since opening.

**Example with 1 litre/pulse resolution:**
- Counter is at 0.99 L into the current pulse when the valve opens
- The first tick fires after only 0.01 L of actual flow (~0.6 s on a 3 l/min circuit)
- Yet it is counted as 1 L → apparent flow = 100 l/min instead of 3 l/min

**The effect is amplified on low-flow circuits:** a line running at 3 l/min
accumulates 1 litre every ~20 s, so the ratio between the erroneous
`volume_delta` and the very short `time_delta` is much larger than on a
high-flow circuit (17 l/min, 1 pulse every ~3.5 s).

This was confirmed experimentally: the spike only appears at the start of a
zone (after `start_record`), and the first reliable sensor value arrives
exactly after the first full litre has been consumed since opening.

![Flow rate spike before fix]
<img width="1274" height="1096" alt="image" src="https://github.com/user-attachments/assets/8c553096-cab9-4cef-b98a-ce99d3ebb1bc" />


## Fix

In `_read_sensor`, when `_total_readings == 1` (i.e. the second tick, first
interval), reset `_first_reading` to the current tick and discard the
calculation. This ensures all subsequent flow rate calculations start from a
clean, reliable baseline where a complete pulse interval has elapsed since
the valve opened.

`_total_readings` is reset to `0` by `_reset_readings()` on every
`start_record` call, so `_total_readings == 1` unambiguously identifies the
first interval of a new recording — not a tick in the middle of an ongoing run.

## Base

This PR is based on release tag `2025.12.0`, not on the current HEAD of
`master`, to avoid any dependency on unreleased development work. It may be integrated
it into the next release at your convenience.

## Testing

Tested on a production system with:
- 1 pulse/litre flow meter on the main supply line
- 15 circuits in sequence, ranging from 3 l/min to 17 l/min
- Spike completely eliminated on all circuits after fix
- Flow rate stabilises correctly from the third tick onward